### PR TITLE
Allow stdout to be flushed on exit

### DIFF
--- a/bin/base64.js
+++ b/bin/base64.js
@@ -204,7 +204,4 @@ else {
   log(result, options.eol);
 }
 // #endregion
-// #region exit
-process.exit(0);
-// #endregion
 //# sourceMappingURL=cli.js.map

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -192,6 +192,3 @@ if (options.out) {
   log(result, options.eol);
 }
 // #endregion
-// #region exit
-process.exit(0);
-// #endregion


### PR DESCRIPTION
Currently, the CLI script explicitly calls process.exit(0) on successful termination. This prevents stdout from draining, and when using output to stdout, the output can be truncated.

Since Node will return an exit code of 0 on non-error termination in any case, the simplest fix is to remove this process.exit(0) call from the end of the script. When Node shuts down it will first drain stdout.